### PR TITLE
feat(chat functionality): add sub_user_id support and enhance answer …

### DIFF
--- a/backend/api/quivr_api/modules/chat/controller/chat_routes.py
+++ b/backend/api/quivr_api/modules/chat/controller/chat_routes.py
@@ -182,7 +182,7 @@ async def create_question_handler(
     brain_id: Annotated[UUID | None, Query()] = None,
 ):
     models = await model_service.get_models()
- 
+
     model_to_use = None
     # Check if the brain_id is a model name hashed to a uuid and then returns the model name
     for model in models:
@@ -194,7 +194,6 @@ async def create_question_handler(
  
     try:
         if model_to_use is None:
-            logger.info(f"11-----")
             assert brain_id
             brain = brain_service.get_brain_details(brain_id, current_user.id)
             assert brain is not None
@@ -224,7 +223,6 @@ async def create_question_handler(
                 vector_service=vector_service,
             )
         else:
-            logger.info(f"22-----")
             await check_and_update_user_usage(
                 current_user, model_to_use.name, model_service
             )
@@ -245,7 +243,8 @@ async def create_question_handler(
             )
         assert service is not None
         maybe_send_telemetry("question_asked", {"streaming": True}, request)
-        chat_answer = await service.generate_answer(chat_question.question)
+        payloadMetadata = {"sub_user_id": chat_question.sub_user_id}
+        chat_answer = await service.generate_answer(chat_question.question, payloadMetadata)
         logger.info(f"chat_answer: {chat_answer}")
         return chat_answer
     
@@ -297,7 +296,6 @@ async def create_stream_question_handler(
             break
     try:
         if model_to_use is None:
-            logger.info(f"11-----")
             assert brain_id
             brain = brain_service.get_brain_details(brain_id, current_user.id)
             assert brain is not None
@@ -327,7 +325,6 @@ async def create_stream_question_handler(
                 vector_service=vector_service,
             )
         else:
-            logger.info(f"22-----")
             await check_and_update_user_usage(
                 current_user, model_to_use.name, model_service
             )  # type: ignore
@@ -350,8 +347,9 @@ async def create_stream_question_handler(
         background_tasks.add_task(
             maybe_send_telemetry, "question_asked", {"streaming": True}, request
         )
+        payloadMetadata = {"sub_user_id": chat_question.sub_user_id}
         return StreamingResponse(
-            service.generate_answer_stream(chat_question.question),
+            service.generate_answer_stream(chat_question.question, payloadMetadata),
             media_type="text/event-stream",
         )
 

--- a/backend/api/quivr_api/modules/chat/dto/chats.py
+++ b/backend/api/quivr_api/modules/chat/dto/chats.py
@@ -26,6 +26,7 @@ class ChatQuestion(BaseModel):
     max_tokens: Optional[int] = None
     brain_id: Optional[UUID] = None
     prompt_id: Optional[UUID] = None
+    sub_user_id: Optional[str] = None
 
 
 class Sources(BaseModel):

--- a/backend/api/quivr_api/modules/rag_service/rag_service.py
+++ b/backend/api/quivr_api/modules/rag_service/rag_service.py
@@ -194,6 +194,7 @@ class RAGService:
     async def generate_answer(
         self,
         question: str,
+        payloadMetadata: dict,
     ):
         logger.info(
             f"Creating question for chat {self.chat_id} with brain {self.brain.brain_id} "
@@ -256,6 +257,7 @@ class RAGService:
         )
         metadata["snippet_color"] = self.brain.snippet_color if self.brain else None
         metadata["snippet_emoji"] = self.brain.snippet_emoji if self.brain else None
+        metadata.update(payloadMetadata)
         return GetChatHistoryOutput(
             **{
                 "chat_id": self.chat_id,
@@ -283,6 +285,7 @@ class RAGService:
     async def generate_answer_stream(
         self,
         question: str,
+        payloadMetadata: dict,
     ):
         logger.info(
             f"Creating question for chat {self.chat_id} with brain {self.brain.brain_id} "
@@ -329,6 +332,7 @@ class RAGService:
         metadata = {}
         metadata["snippet_color"] = self.brain.snippet_color if self.brain else None
         metadata["snippet_emoji"] = self.brain.snippet_emoji if self.brain else None
+        metadata.update(payloadMetadata)
         message_metadata = {
             "chat_id": self.chat_id,
             "message_id": uuid4(),  # do we need it ?,

--- a/backend/api/quivr_api/modules/zalo/controller/zalo_routes.py
+++ b/backend/api/quivr_api/modules/zalo/controller/zalo_routes.py
@@ -33,6 +33,9 @@ async def zalo_webhook(
     try:
         data = await request.json()
         logger.info(f"Zalo webhook received with data: {data}")
+        message_id = data.get("message").get("msg_id")
+        if message_id == 'This is message id':
+            return {"message": "Zalo webhook received", "data": data}
         # Handle event user send text
         if data.get("event_name") == "user_send_text":
             message = data.get("message").get("text")
@@ -57,9 +60,9 @@ async def zalo_webhook(
                 vector_service
             )
             logger.info(f"Chat answer: {chat_answer}")
+            assert chat_answer is not None
+            await zalo_service.send_zalo_message(data.get("sender").get("id"), chat_answer.assistant)
 
-        # assert chat_answer is not None
-        # await zalo_service.send_zalo_message(data.get("sender").get("id"), "Tôi là bot")
         return {"message": "Zalo webhook received", "data": data, "chat_answer": chat_answer}
     except Exception as e:
         logger.error(f"Error processing Zalo webhook: {e}")


### PR DESCRIPTION
…generation

- Introduced `sub_user_id` field in `ChatQuestion` model to track sub-user interactions.
- Updated `create_question_handler` and `create_stream_question_handler` to pass `payloadMetadata` including `sub_user_id` to the answer generation methods.
- Enhanced `generate_answer` and `generate_answer_stream` methods in `RAGService` to incorporate `payloadMetadata` for improved context handling.
- Modified Zalo webhook to handle specific message IDs and ensure proper response handling.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
